### PR TITLE
Force windows_service to restart in order to cope with restart error:

### DIFF
--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -116,6 +116,7 @@ service 'datadog-agent' do
   provider service_provider unless service_provider.nil?
   if is_windows
     supports :restart => true, :start => true, :stop => true
+    restart_command "powershell restart-service #{node['datadog']['agent_name']} -Force"
   else
     supports :restart => true, :status => true, :start => true, :stop => true
   end


### PR DESCRIPTION
"Cannot stop service 'Datadog Agent (DatadogAgent)' because it has dependent services.'"